### PR TITLE
Fix annual inspection list page error

### DIFF
--- a/app/templates/annual_inspection/list.html
+++ b/app/templates/annual_inspection/list.html
@@ -37,14 +37,14 @@
                         <td>{{ forklift.management_number }}</td>
                         <td>{{ forklift.manufacturer }}</td>
                         <td>{{ forklift.model }}</td>
-                        <td>{{ prediction.annual_inspection_date.strftime('%Y-%m-%d') if prediction.annual_inspection_date else '-' }}</td>
-                        <td>{{ prediction.next_annual_inspection_date.strftime('%Y-%m-%d') if prediction.next_annual_inspection_date else '-' }}</td>
+                        <td>{{ prediction.annual_inspection_date.strftime('%Y-%m-%d') if prediction and prediction.annual_inspection_date else '-' }}</td>
+                        <td>{{ prediction.next_annual_inspection_date.strftime('%Y-%m-%d') if prediction and prediction.next_annual_inspection_date else '-' }}</td>
                         <td>
-                            {% if prediction.annual_inspection_status == 'passed' %}
+                            {% if prediction and prediction.annual_inspection_status == 'passed' %}
                             <span class="badge bg-success">合格</span>
-                            {% elif prediction.annual_inspection_status == 'failed' %}
+                            {% elif prediction and prediction.annual_inspection_status == 'failed' %}
                             <span class="badge bg-danger">不合格</span>
-                            {% elif prediction.annual_inspection_status == 'pending' %}
+                            {% elif prediction and prediction.annual_inspection_status == 'pending' %}
                             <span class="badge bg-warning">保留</span>
                             {% else %}
                             <span class="badge bg-secondary">未設定</span>


### PR DESCRIPTION
## 概要
年次点検一覧ページでエラーが発生する問題を修正しました。

## 変更内容
1. 年次点検一覧取得のクエリを修正
   - LEFT OUTER JOINを使用して予測データがないフォークリフトも含めるように変更
   - アクティブなフォークリフトのみ表示するフィルターを追加
   - 次回点検日順、次に管理番号順でソートするように変更
2. テンプレートを修正して予測データがない場合にエラーが発生しないように対応
3. エラーハンドリングを追加

## 関連Issue
Closes #28

## テスト方法
1. 年次点検一覧ページにアクセス
2. 予測データがないフォークリフトも含めて正しく表示されることを確認
3. 点検管理ボタンをクリックして正常に動作することを確認