### PR TITLE
Fix forklift detail page error

### DIFF
--- a/app/templates/forklift/view.html
+++ b/app/templates/forklift/view.html
@@ -202,21 +202,22 @@
     </div>
 </div>
 
-{% if prediction.annual_inspection_date and prediction.annual_inspection_status %}
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="card-title mb-0">年次点検情報</h5>
         <a href="{{ url_for('annual_inspection.manage_annual_inspection', forklift_id=forklift.id) }}" class="btn btn-sm btn-primary">
-            <i class="bi bi-pencil"></i> 編集
+            <i class="bi bi-pencil"></i> {% if prediction and prediction.annual_inspection_date %}編集{% else %}登録{% endif %}
         </a>
     </div>
+    
+    {% if prediction and prediction.annual_inspection_date and prediction.annual_inspection_status %}
     <div class="card-body">
         <div class="row">
             <div class="col-md-6">
                 <table class="table table-bordered">
                     <tr>
                         <th style="width: 40%">前回点検日</th>
-                        <td>{{ prediction.annual_inspection_date.strftime('%Y-%m-%d') }}</td>
+                        <td>{{ prediction.annual_inspection_date.strftime('%Y-%m-%d') if prediction.annual_inspection_date else '未設定' }}</td>
                     </tr>
                     <tr>
                         <th>次回点検予定日</th>
@@ -254,9 +255,12 @@
             </div>
         </div>
     </div>
+    {% else %}
+    <div class="card-body">
+        <p class="text-center">年次点検情報はまだ登録されていません。「登録」ボタンをクリックして情報を追加してください。</p>
+    </div>
+    {% endif %}
 </div>
-{% endif %}
-{% endif %}
 
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## 概要
フォークリフト詳細表示ページでエラーが発生する問題を修正しました。

## 変更内容
1. フォークリフト詳細表示ルートにエラーハンドリングを追加
2. 予測データがない場合は自動的に作成するよう修正
3. テンプレートを修正して予測データがない場合でも適切に表示するよう対応
4. 年次点検情報がない場合でも点検管理ボタンを表示するよう改善

## 関連Issue
Closes #29

## テスト方法
1. フォークリフト一覧から詳細ページにアクセス
2. 予測データがないフォークリフトでも正しく表示されることを確認
3. 年次点検情報がない場合でも「登録」ボタンが表示されることを確認