### PR TITLE
Simplify operator management to use login user

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -42,6 +42,11 @@ def login():
             user.last_login = datetime.utcnow()
             db.session.commit()
             
+            # ログインユーザーを操作者として設定
+            from flask import session
+            session['current_operator_id'] = user.id
+            session['current_operator_name'] = user.full_name or user.username
+            
             next_page = request.args.get('next')
             if not next_page or not next_page.startswith('/'):
                 next_page = url_for('main.index')
@@ -56,6 +61,11 @@ def login():
 @auth_bp.route('/logout')
 @login_required
 def logout():
+    # 操作者情報をクリア
+    from flask import session
+    session.pop('current_operator_id', None)
+    session.pop('current_operator_name', None)
+    
     logout_user()
     flash('ログアウトしました。', 'info')
     return redirect(url_for('auth.login'))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -92,13 +92,12 @@
                 </ul>
                 <div class="d-flex align-items-center">
                     <!-- 操作者名表示 -->
+                    {% if current_user.is_authenticated %}
                     <div class="input-group me-2">
                         <span class="input-group-text"><i class="bi bi-person-badge"></i></span>
-                        <input type="text" class="form-control" id="global-operator-name" placeholder="操作者名を設定" readonly>
-                        <button class="btn btn-outline-secondary" type="button" data-bs-toggle="modal" data-bs-target="#operatorModal">
-                            <i class="bi bi-pencil"></i>
-                        </button>
+                        <input type="text" class="form-control" id="global-operator-name" value="{{ current_user.full_name or current_user.username }}" readonly>
                     </div>
+                    {% endif %}
                     
                     {% if current_user.is_authenticated %}
                     <div class="dropdown">
@@ -160,20 +159,10 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
-        // 操作者名をローカルストレージに保存
+        // フォームに操作者名を自動設定
         document.addEventListener('DOMContentLoaded', function() {
             const operatorInput = document.getElementById('global-operator-name');
-            
-            // ローカルストレージから操作者名を取得
-            const savedOperator = localStorage.getItem('operatorName');
-            if (savedOperator) {
-                operatorInput.value = savedOperator;
-            }
-            
-            // 操作者名が変更されたらローカルストレージに保存
-            operatorInput.addEventListener('change', function() {
-                localStorage.setItem('operatorName', this.value);
-            });
+            if (!operatorInput) return;
             
             // フォームに操作者名を自動設定
             const forms = document.querySelectorAll('form');

--- a/app/templates/components/operator_modal.html
+++ b/app/templates/components/operator_modal.html
@@ -3,27 +3,19 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="operatorModalLabel">操作者名を選択または入力してください</h5>
+                <h5 class="modal-title" id="operatorModalLabel">操作者情報</h5>
             </div>
             <div class="modal-body">
-                <div class="mb-3">
-                    <label for="operatorSelect" class="form-label">登録済み操作者から選択</label>
-                    <select class="form-select" id="operatorSelect">
-                        <option value="">-- 選択してください --</option>
-                        <!-- APIから動的に読み込み -->
-                    </select>
-                </div>
-                
-                <div class="mb-3">
-                    <label for="operatorInput" class="form-label">または新しい操作者名を入力</label>
-                    <input type="text" class="form-control" id="operatorInput" placeholder="例：山田太郎">
+                <div class="alert alert-info">
+                    <p>現在のシステムでは、ログインユーザーが自動的に操作者として設定されます。</p>
+                    <p>操作者名: <strong id="currentUserName">{{ current_user.full_name or current_user.username }}</strong></p>
                 </div>
                 
                 <!-- エラーメッセージ表示エリア -->
                 <div class="alert alert-danger d-none" id="operatorErrorMessage"></div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" id="setOperatorBtn">設定する</button>
+                <button type="button" class="btn btn-primary" id="setOperatorBtn">確認</button>
             </div>
         </div>
     </div>
@@ -32,60 +24,7 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const operatorModal = document.getElementById('operatorModal');
-        const operatorSelect = document.getElementById('operatorSelect');
-        const operatorInput = document.getElementById('operatorInput');
         const setOperatorBtn = document.getElementById('setOperatorBtn');
-        
-        // モーダルが表示されたときに操作者リストを読み込む
-        operatorModal.addEventListener('show.bs.modal', function() {
-            // 既存の選択肢をクリア
-            while (operatorSelect.options.length > 1) {
-                operatorSelect.remove(1);
-            }
-            
-            // APIから操作者リストを取得
-            fetch('/operator/api/list')
-                .then(response => response.json())
-                .then(data => {
-                    data.forEach(operator => {
-                        const option = document.createElement('option');
-                        option.value = operator.id;
-                        option.textContent = `${operator.name} (${operator.employee_id})`;
-                        operatorSelect.appendChild(option);
-                    });
-                })
-                .catch(error => console.error('操作者リストの取得に失敗しました:', error));
-            
-            // 現在の操作者情報を取得
-            fetch('/operator/api/get_current')
-                .then(response => response.json())
-                .then(data => {
-                    if (data.success) {
-                        // セッションに保存されている操作者がいれば選択
-                        for (let i = 0; i < operatorSelect.options.length; i++) {
-                            if (operatorSelect.options[i].value == data.operator_id) {
-                                operatorSelect.selectedIndex = i;
-                                break;
-                            }
-                        }
-                    }
-                })
-                .catch(error => console.error('現在の操作者情報の取得に失敗しました:', error));
-        });
-        
-        // 操作者選択時に入力フィールドをクリア
-        operatorSelect.addEventListener('change', function() {
-            if (this.value) {
-                operatorInput.value = '';
-            }
-        });
-        
-        // 操作者入力時に選択をクリア
-        operatorInput.addEventListener('input', function() {
-            if (this.value) {
-                operatorSelect.selectedIndex = 0;
-            }
-        });
         
         // エラーメッセージ表示エリア
         const errorMessageArea = document.getElementById('operatorErrorMessage');
@@ -102,81 +41,11 @@
             errorMessageArea.textContent = '';
         }
         
-        // 操作者設定ボタンクリック時の処理
+        // 確認ボタンクリック時の処理
         setOperatorBtn.addEventListener('click', function() {
-            // エラーメッセージをクリア
-            hideErrorMessage();
-            
-            let operatorId = null;
-            let operatorName = null;
-            
-            if (operatorSelect.value) {
-                operatorId = operatorSelect.value;
-                operatorName = operatorSelect.options[operatorSelect.selectedIndex].textContent.split(' (')[0];
-            } else if (operatorInput.value.trim()) {
-                operatorName = operatorInput.value.trim();
-            } else {
-                showErrorMessage('操作者を選択または入力してください');
-                return;
-            }
-            
-            // ボタンを無効化して二重送信を防止
-            setOperatorBtn.disabled = true;
-            setOperatorBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> 処理中...';
-            
-            // APIに操作者情報を送信
-            // CSRFトークンを取得
-            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-            
-            fetch('/operator/api/set_current', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': csrfToken
-                },
-                body: JSON.stringify({
-                    operator_id: operatorId,
-                    operator_name: operatorName
-                }),
-                credentials: 'same-origin'
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`サーバーエラー: ${response.status}`);
-                }
-                return response.json();
-            })
-            .then(data => {
-                if (data.success) {
-                    // ローカルストレージに保存
-                    localStorage.setItem('operatorName', data.name);
-                    
-                    // グローバル操作者名表示を更新
-                    const globalOperatorName = document.getElementById('global-operator-name');
-                    if (globalOperatorName) {
-                        globalOperatorName.value = data.name;
-                    }
-                    
-                    // モーダルを閉じる
-                    const modal = bootstrap.Modal.getInstance(operatorModal);
-                    modal.hide();
-                    
-                    // ページをリロード
-                    location.reload();
-                } else {
-                    showErrorMessage('操作者の設定に失敗しました: ' + (data.error || '不明なエラー'));
-                    // ボタンを再度有効化
-                    setOperatorBtn.disabled = false;
-                    setOperatorBtn.textContent = '設定する';
-                }
-            })
-            .catch(error => {
-                console.error('操作者の設定に失敗しました:', error);
-                showErrorMessage('操作者の設定に失敗しました: ' + error.message);
-                // ボタンを再度有効化
-                setOperatorBtn.disabled = false;
-                setOperatorBtn.textContent = '設定する';
-            });
+            // モーダルを閉じる
+            const modal = bootstrap.Modal.getInstance(operatorModal);
+            modal.hide();
         });
         
         // ページ読み込み時に操作者が設定されていなければモーダルを表示


### PR DESCRIPTION
## 概要
ログインユーザーアカウントを操作者名として設定するように変更しました。

## 変更内容
1. ログイン時に自動的にログインユーザーを操作者として設定
2. ログアウト時に操作者情報をクリア
3. 操作者選択モーダルを簡略化し、ログインユーザー情報を表示するのみに変更
4. ナビゲーションバーの操作者表示部分を修正
5. 関連するJavaScriptを簡略化

## 関連Issue
Closes #21

## テスト方法
1. ログインすると自動的に操作者名が設定されることを確認
2. 操作者情報モーダルを開くとログインユーザー名が表示されることを確認
3. 各種フォーム送信時に操作者名が自動的に設定されることを確認