### PR TITLE
Improve repair history management

### DIFF
--- a/app/routes/repair.py
+++ b/app/routes/repair.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
 from app.models import db, AuditLog
-from app.models.forklift import ForkliftRepair
-from app.models.facility import FacilityRepair
+from app.models.forklift import Forklift, ForkliftRepair
+from app.models.facility import Facility, FacilityRepair
 from app.models.other_repair import OtherRepair
+from app.models.master import WarehouseGroup
 from datetime import datetime
 import os
 from werkzeug.utils import secure_filename
@@ -12,17 +13,106 @@ repair_bp = Blueprint('repair', __name__)
 
 @repair_bp.route('/')
 def index():
-    # 修繕履歴一覧を取得
-    forklift_repairs = ForkliftRepair.query.order_by(ForkliftRepair.repair_date.desc()).all()
-    facility_repairs = FacilityRepair.query.order_by(FacilityRepair.repair_date.desc()).all()
-    other_repairs = OtherRepair.query.order_by(OtherRepair.repair_date.desc()).all()
+    # 検索パラメータを取得
+    search_type = request.args.get('type', 'all')
+    search_keyword = request.args.get('keyword', '')
+    search_date_from = request.args.get('date_from', '')
+    search_date_to = request.args.get('date_to', '')
+    search_reason = request.args.get('reason', '')
+    
+    # 日付の変換
+    date_from = None
+    date_to = None
+    try:
+        if search_date_from:
+            date_from = datetime.strptime(search_date_from, '%Y-%m-%d').date()
+        if search_date_to:
+            date_to = datetime.strptime(search_date_to, '%Y-%m-%d').date()
+    except ValueError:
+        flash('日付の形式が正しくありません。', 'danger')
+    
+    # フォークリフト修繕履歴のクエリ
+    forklift_query = ForkliftRepair.query
+    
+    # 検索条件の適用
+    if search_keyword:
+        forklift_query = forklift_query.filter(
+            (ForkliftRepair.repair_item.ilike(f'%{search_keyword}%')) |
+            (ForkliftRepair.forklift_management_number.ilike(f'%{search_keyword}%')) |
+            (ForkliftRepair.vendor.ilike(f'%{search_keyword}%')) |
+            (ForkliftRepair.notes.ilike(f'%{search_keyword}%'))
+        )
+    
+    if date_from:
+        forklift_query = forklift_query.filter(ForkliftRepair.repair_date >= date_from)
+    if date_to:
+        forklift_query = forklift_query.filter(ForkliftRepair.repair_date <= date_to)
+    if search_reason:
+        forklift_query = forklift_query.filter(ForkliftRepair.repair_reason == search_reason)
+    
+    # 倉庫施設修繕履歴のクエリ
+    facility_query = FacilityRepair.query
+    
+    # 検索条件の適用
+    if search_keyword:
+        facility_query = facility_query.filter(
+            (FacilityRepair.repair_item.ilike(f'%{search_keyword}%')) |
+            (FacilityRepair.facility_name.ilike(f'%{search_keyword}%')) |
+            (FacilityRepair.vendor.ilike(f'%{search_keyword}%')) |
+            (FacilityRepair.notes.ilike(f'%{search_keyword}%'))
+        )
+    
+    if date_from:
+        facility_query = facility_query.filter(FacilityRepair.repair_date >= date_from)
+    if date_to:
+        facility_query = facility_query.filter(FacilityRepair.repair_date <= date_to)
+    if search_reason:
+        facility_query = facility_query.filter(FacilityRepair.repair_reason == search_reason)
+    
+    # その他修繕履歴のクエリ
+    other_query = OtherRepair.query
+    
+    # 検索条件の適用
+    if search_keyword:
+        other_query = other_query.filter(
+            (OtherRepair.repair_item.ilike(f'%{search_keyword}%')) |
+            (OtherRepair.repair_target.ilike(f'%{search_keyword}%')) |
+            (OtherRepair.vendor.ilike(f'%{search_keyword}%')) |
+            (OtherRepair.notes.ilike(f'%{search_keyword}%'))
+        )
+    
+    if date_from:
+        other_query = other_query.filter(OtherRepair.repair_date >= date_from)
+    if date_to:
+        other_query = other_query.filter(OtherRepair.repair_date <= date_to)
+    
+    # タイプによるフィルタリング
+    if search_type == 'forklift':
+        facility_query = facility_query.filter(FacilityRepair.id < 0)  # 空のクエリにする
+        other_query = other_query.filter(OtherRepair.id < 0)  # 空のクエリにする
+    elif search_type == 'facility':
+        forklift_query = forklift_query.filter(ForkliftRepair.id < 0)  # 空のクエリにする
+        other_query = other_query.filter(OtherRepair.id < 0)  # 空のクエリにする
+    elif search_type == 'other':
+        forklift_query = forklift_query.filter(ForkliftRepair.id < 0)  # 空のクエリにする
+        facility_query = facility_query.filter(FacilityRepair.id < 0)  # 空のクエリにする
+    
+    # 結果の取得
+    forklift_repairs = forklift_query.order_by(ForkliftRepair.repair_date.desc()).all()
+    facility_repairs = facility_query.order_by(FacilityRepair.repair_date.desc()).all()
+    other_repairs = other_query.order_by(OtherRepair.repair_date.desc()).all()
     
     return render_template('repair/index.html',
                           forklift_repairs=forklift_repairs,
                           facility_repairs=facility_repairs,
                           other_repairs=other_repairs,
                           repair_target_types=Config.REPAIR_TARGET_TYPE_NAMES,
-                          repair_reasons=Config.REPAIR_REASON_NAMES)
+                          repair_reasons=Config.REPAIR_REASON_NAMES,
+                          search_type=search_type,
+                          search_keyword=search_keyword,
+                          search_date_from=search_date_from,
+                          search_date_to=search_date_to,
+                          search_reason=search_reason)
 
 @repair_bp.route('/forklift/<int:id>')
 def view_forklift_repair(id):
@@ -38,6 +128,249 @@ def view_facility_repair(id):
 def view_other_repair(id):
     repair = OtherRepair.query.get_or_404(id)
     return render_template('repair/view_other.html', repair=repair)
+
+@repair_bp.route('/create')
+def create_select():
+    """修繕対象選択ページ"""
+    return render_template('repair/create_select.html')
+
+@repair_bp.route('/create/forklift')
+def create_forklift_repair_select():
+    """フォークリフト選択ページ"""
+    # 検索パラメータを取得
+    search_keyword = request.args.get('keyword', '')
+    search_warehouse_group = request.args.get('warehouse_group', '')
+    
+    # フォークリフトのクエリ
+    query = Forklift.query.filter_by(asset_status='active')
+    
+    # 検索条件の適用
+    if search_keyword:
+        query = query.filter(
+            (Forklift.management_number.ilike(f'%{search_keyword}%')) |
+            (Forklift.manufacturer.ilike(f'%{search_keyword}%')) |
+            (Forklift.model.ilike(f'%{search_keyword}%'))
+        )
+    
+    if search_warehouse_group:
+        query = query.filter(Forklift.warehouse_group == search_warehouse_group)
+    
+    # 結果の取得
+    forklifts = query.order_by(Forklift.management_number).all()
+    
+    # 倉庫グループの取得
+    warehouse_groups = WarehouseGroup.query.filter_by(is_active=True).all()
+    
+    return render_template('repair/create_forklift_select.html',
+                          forklifts=forklifts,
+                          warehouse_groups=warehouse_groups,
+                          search_keyword=search_keyword,
+                          search_warehouse_group=search_warehouse_group)
+
+@repair_bp.route('/create/facility')
+def create_facility_repair_select():
+    """倉庫施設選択ページ"""
+    # 検索パラメータを取得
+    search_keyword = request.args.get('keyword', '')
+    search_warehouse_group = request.args.get('warehouse_group', '')
+    
+    # 倉庫施設のクエリ
+    query = Facility.query.filter_by(asset_status='active')
+    
+    # 検索条件の適用
+    if search_keyword:
+        query = query.filter(
+            (Facility.name.ilike(f'%{search_keyword}%')) |
+            (Facility.address.ilike(f'%{search_keyword}%'))
+        )
+    
+    if search_warehouse_group:
+        query = query.filter(Facility.warehouse_group == search_warehouse_group)
+    
+    # 結果の取得
+    facilities = query.order_by(Facility.name).all()
+    
+    # 倉庫グループの取得
+    warehouse_groups = WarehouseGroup.query.filter_by(is_active=True).all()
+    
+    return render_template('repair/create_facility_select.html',
+                          facilities=facilities,
+                          warehouse_groups=warehouse_groups,
+                          search_keyword=search_keyword,
+                          search_warehouse_group=search_warehouse_group)
+
+@repair_bp.route('/create/forklift/<int:forklift_id>', methods=['GET', 'POST'])
+def create_forklift_repair(forklift_id):
+    """フォークリフト修繕登録"""
+    forklift = Forklift.query.get_or_404(forklift_id)
+    
+    if request.method == 'POST':
+        try:
+            # フォームからデータを取得
+            repair_date = datetime.strptime(request.form['repair_date'], '%Y-%m-%d').date()
+            repair_target_type = request.form['repair_target_type']
+            repair_item = request.form['repair_item']
+            repair_cost = int(request.form['repair_cost'])
+            repair_reason = request.form['repair_reason']
+            vendor = request.form['vendor']
+            notes = request.form.get('notes', '')
+            
+            # 修繕履歴を作成
+            repair = ForkliftRepair(
+                forklift_id=forklift.id,
+                forklift_management_number=forklift.management_number,
+                repair_date=repair_date,
+                repair_target_type=repair_target_type,
+                repair_item=repair_item,
+                repair_cost=repair_cost,
+                repair_reason=repair_reason,
+                vendor=vendor,
+                notes=notes,
+                operator=request.form.get('operator_name', 'システム')
+            )
+            
+            # ファイルアップロード処理
+            if 'photo' in request.files and request.files['photo'].filename:
+                photo = request.files['photo']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{photo.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'forklift', str(forklift.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                photo_path = os.path.join(upload_dir, filename)
+                photo.save(photo_path)
+                repair.photo_path = f"/static/uploads/forklift/{forklift.id}/{filename}"
+            
+            if 'quotation' in request.files and request.files['quotation'].filename:
+                quotation = request.files['quotation']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{quotation.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'forklift', str(forklift.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                quotation_path = os.path.join(upload_dir, filename)
+                quotation.save(quotation_path)
+                repair.quotation_path = f"/static/uploads/forklift/{forklift.id}/{filename}"
+            
+            if 'approval_document' in request.files and request.files['approval_document'].filename:
+                approval_document = request.files['approval_document']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{approval_document.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'forklift', str(forklift.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                approval_document_path = os.path.join(upload_dir, filename)
+                approval_document.save(approval_document_path)
+                repair.approval_document_path = f"/static/uploads/forklift/{forklift.id}/{filename}"
+            
+            db.session.add(repair)
+            db.session.commit()
+            
+            # 監査ログを記録
+            audit_log = AuditLog(
+                action='create',
+                entity_type='forklift_repair',
+                entity_id=repair.id,
+                operator=request.form.get('operator_name', 'システム'),
+                details=f'フォークリフト {forklift.management_number} の修繕履歴を登録'
+            )
+            db.session.add(audit_log)
+            db.session.commit()
+            
+            flash('フォークリフト修繕履歴が正常に登録されました。', 'success')
+            return redirect(url_for('forklift.view', id=forklift.id))
+            
+        except Exception as e:
+            db.session.rollback()
+            flash(f'エラーが発生しました: {str(e)}', 'danger')
+    
+    return render_template('repair/create_forklift.html',
+                          forklift=forklift,
+                          repair_target_types=Config.REPAIR_TARGET_TYPE_NAMES,
+                          repair_reasons=Config.REPAIR_REASON_NAMES)
+
+@repair_bp.route('/create/facility/<int:facility_id>', methods=['GET', 'POST'])
+def create_facility_repair(facility_id):
+    """倉庫施設修繕登録"""
+    facility = Facility.query.get_or_404(facility_id)
+    
+    if request.method == 'POST':
+        try:
+            # フォームからデータを取得
+            repair_date = datetime.strptime(request.form['repair_date'], '%Y-%m-%d').date()
+            floor = request.form['floor']
+            contractor = request.form['contractor']
+            repair_item = request.form['repair_item']
+            repair_cost = int(request.form['repair_cost'])
+            repair_reason = request.form['repair_reason']
+            notes = request.form.get('notes', '')
+            
+            # 修繕履歴を作成
+            repair = FacilityRepair(
+                facility_id=facility.id,
+                facility_name=facility.name,
+                repair_date=repair_date,
+                floor=floor,
+                contractor=contractor,
+                repair_item=repair_item,
+                repair_cost=repair_cost,
+                repair_reason=repair_reason,
+                notes=notes,
+                operator=request.form.get('operator_name', 'システム')
+            )
+            
+            # ファイルアップロード処理
+            if 'photo' in request.files and request.files['photo'].filename:
+                photo = request.files['photo']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{photo.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'facility', str(facility.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                photo_path = os.path.join(upload_dir, filename)
+                photo.save(photo_path)
+                repair.photo_path = f"/static/uploads/facility/{facility.id}/{filename}"
+            
+            if 'quotation' in request.files and request.files['quotation'].filename:
+                quotation = request.files['quotation']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{quotation.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'facility', str(facility.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                quotation_path = os.path.join(upload_dir, filename)
+                quotation.save(quotation_path)
+                repair.quotation_path = f"/static/uploads/facility/{facility.id}/{filename}"
+            
+            if 'approval_document' in request.files and request.files['approval_document'].filename:
+                approval_document = request.files['approval_document']
+                filename = secure_filename(f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{approval_document.filename}")
+                upload_dir = os.path.join(current_app.config['UPLOAD_FOLDER'], 'facility', str(facility.id))
+                if not os.path.exists(upload_dir):
+                    os.makedirs(upload_dir)
+                approval_document_path = os.path.join(upload_dir, filename)
+                approval_document.save(approval_document_path)
+                repair.approval_document_path = f"/static/uploads/facility/{facility.id}/{filename}"
+            
+            db.session.add(repair)
+            db.session.commit()
+            
+            # 監査ログを記録
+            audit_log = AuditLog(
+                action='create',
+                entity_type='facility_repair',
+                entity_id=repair.id,
+                operator=request.form.get('operator_name', 'システム'),
+                details=f'倉庫施設 {facility.name} の修繕履歴を登録'
+            )
+            db.session.add(audit_log)
+            db.session.commit()
+            
+            flash('倉庫施設修繕履歴が正常に登録されました。', 'success')
+            return redirect(url_for('facility.view', id=facility.id))
+            
+        except Exception as e:
+            db.session.rollback()
+            flash(f'エラーが発生しました: {str(e)}', 'danger')
+    
+    return render_template('repair/create_facility.html',
+                          facility=facility,
+                          repair_reasons=Config.REPAIR_REASON_NAMES)
 
 @repair_bp.route('/forklift/<int:id>/edit', methods=['GET', 'POST'])
 def edit_forklift_repair(id):

--- a/app/templates/facility/view.html
+++ b/app/templates/facility/view.html
@@ -119,7 +119,7 @@
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="card-title mb-0">修繕履歴</h5>
-        <a href="{{ url_for('facility.add_repair', id=facility.id) }}" class="btn btn-primary btn-sm">
+        <a href="{{ url_for('repair.create_facility_repair', facility_id=facility.id) }}" class="btn btn-primary btn-sm">
             <i class="bi bi-plus-circle"></i> 修繕履歴追加
         </a>
     </div>

--- a/app/templates/forklift/view.html
+++ b/app/templates/forklift/view.html
@@ -261,7 +261,7 @@
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="card-title mb-0">修繕履歴</h5>
-        <a href="{{ url_for('forklift.add_repair', id=forklift.id) }}" class="btn btn-sm btn-primary">
+        <a href="{{ url_for('repair.create_forklift_repair', forklift_id=forklift.id) }}" class="btn btn-sm btn-primary">
             <i class="bi bi-plus-circle"></i> 修繕履歴追加
         </a>
     </div>

--- a/app/templates/repair/create_facility.html
+++ b/app/templates/repair/create_facility.html
@@ -1,0 +1,136 @@
+{% extends "base.html" %}
+
+{% block title %}倉庫施設修繕登録 - 倉庫修繕費管理システム{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>倉庫施設修繕登録</h1>
+    <a href="{{ url_for('repair.create_facility_repair_select') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> 戻る
+    </a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">倉庫施設情報</h5>
+    </div>
+    <div class="card-body">
+        <div class="row">
+            <div class="col-md-6">
+                <table class="table table-bordered">
+                    <tr>
+                        <th style="width: 40%">施設名</th>
+                        <td>{{ facility.name }}</td>
+                    </tr>
+                    <tr>
+                        <th>倉庫グループ</th>
+                        <td>{{ facility.warehouse_group }}</td>
+                    </tr>
+                </table>
+            </div>
+            <div class="col-md-6">
+                <table class="table table-bordered">
+                    <tr>
+                        <th style="width: 40%">住所</th>
+                        <td>{{ facility.address }}</td>
+                    </tr>
+                    <tr>
+                        <th>建築年</th>
+                        <td>{{ facility.construction_year }}年</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h5 class="card-title mb-0">修繕情報登録</h5>
+    </div>
+    <div class="card-body">
+        <form method="post" action="{{ url_for('repair.create_facility_repair', facility_id=facility.id) }}" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="operator_name" value="">
+            
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="repair_date" class="form-label">修繕日 <span class="text-danger">*</span></label>
+                        <input type="date" class="form-control" id="repair_date" name="repair_date" value="{{ today }}" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="floor" class="form-label">階層 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="floor" name="floor" value="1F" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="contractor" class="form-label">施工業者 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="contractor" name="contractor" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="repair_item" class="form-label">修繕項目 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="repair_item" name="repair_item" required>
+                    </div>
+                </div>
+                
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="repair_cost" class="form-label">修繕費用 (円) <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control" id="repair_cost" name="repair_cost" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="repair_reason" class="form-label">修繕理由 <span class="text-danger">*</span></label>
+                        <select class="form-select" id="repair_reason" name="repair_reason" required>
+                            <option value="">-- 選択してください --</option>
+                            {% for reason_key, reason_name in repair_reasons.items() %}
+                            <option value="{{ reason_key }}">{{ reason_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="notes" class="form-label">備考</label>
+                        <textarea class="form-control" id="notes" name="notes" rows="3"></textarea>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="photo" class="form-label">写真</label>
+                        <input type="file" class="form-control" id="photo" name="photo" accept="image/*">
+                    </div>
+                </div>
+                
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="quotation" class="form-label">見積書</label>
+                        <input type="file" class="form-control" id="quotation" name="quotation" accept=".pdf,.jpg,.jpeg,.png">
+                    </div>
+                </div>
+                
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="approval_document" class="form-label">承認書</label>
+                        <input type="file" class="form-control" id="approval_document" name="approval_document" accept=".pdf,.jpg,.jpeg,.png">
+                    </div>
+                </div>
+            </div>
+            
+            <div class="text-center mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-save"></i> 登録する
+                </button>
+                <a href="{{ url_for('repair.create_facility_repair_select') }}" class="btn btn-secondary">
+                    <i class="bi bi-x-circle"></i> キャンセル
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/repair/create_facility_select.html
+++ b/app/templates/repair/create_facility_select.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block title %}倉庫施設修繕登録 - 倉庫修繕費管理システム{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>倉庫施設修繕登録</h1>
+    <a href="{{ url_for('repair.create_select') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> 戻る
+    </a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">倉庫施設検索</h5>
+    </div>
+    <div class="card-body">
+        <form method="get" action="{{ url_for('repair.create_facility_repair_select') }}" class="row g-3">
+            <div class="col-md-4">
+                <label for="keyword" class="form-label">キーワード</label>
+                <input type="text" class="form-control" id="keyword" name="keyword" value="{{ search_keyword }}" placeholder="施設名、住所など">
+            </div>
+            <div class="col-md-4">
+                <label for="warehouse_group" class="form-label">倉庫グループ</label>
+                <select class="form-select" id="warehouse_group" name="warehouse_group">
+                    <option value="">すべて</option>
+                    {% for group in warehouse_groups %}
+                    <option value="{{ group.name }}" {% if search_warehouse_group == group.name %}selected{% endif %}>{{ group.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-search"></i> 検索
+                </button>
+                <a href="{{ url_for('repair.create_facility_repair_select') }}" class="btn btn-secondary ms-2">
+                    <i class="bi bi-x-circle"></i> クリア
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h5 class="card-title mb-0">倉庫施設一覧</h5>
+    </div>
+    <div class="card-body">
+        {% if facilities %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>施設名</th>
+                        <th>倉庫グループ</th>
+                        <th>住所</th>
+                        <th>建築年</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for facility in facilities %}
+                    <tr>
+                        <td>{{ facility.name }}</td>
+                        <td>{{ facility.warehouse_group }}</td>
+                        <td>{{ facility.address }}</td>
+                        <td>{{ facility.construction_year }}</td>
+                        <td>
+                            <a href="{{ url_for('repair.create_facility_repair', facility_id=facility.id) }}" class="btn btn-sm btn-primary">
+                                <i class="bi bi-tools"></i> 修繕登録
+                            </a>
+                            <a href="{{ url_for('facility.view', id=facility.id) }}" class="btn btn-sm btn-info">
+                                <i class="bi bi-eye"></i> 詳細
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center my-3">条件に一致する倉庫施設はありません。</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/repair/create_forklift.html
+++ b/app/templates/repair/create_forklift.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+
+{% block title %}フォークリフト修繕登録 - 倉庫修繕費管理システム{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>フォークリフト修繕登録</h1>
+    <a href="{{ url_for('repair.create_forklift_repair_select') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> 戻る
+    </a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">フォークリフト情報</h5>
+    </div>
+    <div class="card-body">
+        <div class="row">
+            <div class="col-md-6">
+                <table class="table table-bordered">
+                    <tr>
+                        <th style="width: 40%">管理番号</th>
+                        <td>{{ forklift.management_number }}</td>
+                    </tr>
+                    <tr>
+                        <th>メーカー</th>
+                        <td>{{ forklift.manufacturer }}</td>
+                    </tr>
+                    <tr>
+                        <th>機種</th>
+                        <td>{{ forklift.model }}</td>
+                    </tr>
+                </table>
+            </div>
+            <div class="col-md-6">
+                <table class="table table-bordered">
+                    <tr>
+                        <th style="width: 40%">タイプ</th>
+                        <td>{{ forklift.type_name }}</td>
+                    </tr>
+                    <tr>
+                        <th>配置倉庫</th>
+                        <td>{{ forklift.warehouse_group }} {{ forklift.warehouse_number }}</td>
+                    </tr>
+                    <tr>
+                        <th>製造年月日</th>
+                        <td>{{ forklift.manufacture_date.strftime('%Y-%m-%d') }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h5 class="card-title mb-0">修繕情報登録</h5>
+    </div>
+    <div class="card-body">
+        <form method="post" action="{{ url_for('repair.create_forklift_repair', forklift_id=forklift.id) }}" enctype="multipart/form-data">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="operator_name" value="">
+            
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="repair_date" class="form-label">修繕日 <span class="text-danger">*</span></label>
+                        <input type="date" class="form-control" id="repair_date" name="repair_date" value="{{ today }}" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="repair_target_type" class="form-label">修繕対象種別 <span class="text-danger">*</span></label>
+                        <select class="form-select" id="repair_target_type" name="repair_target_type" required>
+                            <option value="">-- 選択してください --</option>
+                            {% for type_key, type_name in repair_target_types.items() %}
+                            <option value="{{ type_key }}">{{ type_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="repair_item" class="form-label">修繕項目 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="repair_item" name="repair_item" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="repair_cost" class="form-label">修繕費用 (円) <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control" id="repair_cost" name="repair_cost" required>
+                    </div>
+                </div>
+                
+                <div class="col-md-6">
+                    <div class="mb-3">
+                        <label for="repair_reason" class="form-label">修繕理由 <span class="text-danger">*</span></label>
+                        <select class="form-select" id="repair_reason" name="repair_reason" required>
+                            <option value="">-- 選択してください --</option>
+                            {% for reason_key, reason_name in repair_reasons.items() %}
+                            <option value="{{ reason_key }}">{{ reason_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="vendor" class="form-label">業者 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="vendor" name="vendor" required>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="notes" class="form-label">備考</label>
+                        <textarea class="form-control" id="notes" name="notes" rows="3"></textarea>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="photo" class="form-label">写真</label>
+                        <input type="file" class="form-control" id="photo" name="photo" accept="image/*">
+                    </div>
+                </div>
+                
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="quotation" class="form-label">見積書</label>
+                        <input type="file" class="form-control" id="quotation" name="quotation" accept=".pdf,.jpg,.jpeg,.png">
+                    </div>
+                </div>
+                
+                <div class="col-md-4">
+                    <div class="mb-3">
+                        <label for="approval_document" class="form-label">承認書</label>
+                        <input type="file" class="form-control" id="approval_document" name="approval_document" accept=".pdf,.jpg,.jpeg,.png">
+                    </div>
+                </div>
+            </div>
+            
+            <div class="text-center mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-save"></i> 登録する
+                </button>
+                <a href="{{ url_for('repair.create_forklift_repair_select') }}" class="btn btn-secondary">
+                    <i class="bi bi-x-circle"></i> キャンセル
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/repair/create_forklift_select.html
+++ b/app/templates/repair/create_forklift_select.html
@@ -1,0 +1,88 @@
+{% extends "base.html" %}
+
+{% block title %}フォークリフト修繕登録 - 倉庫修繕費管理システム{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>フォークリフト修繕登録</h1>
+    <a href="{{ url_for('repair.create_select') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> 戻る
+    </a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">フォークリフト検索</h5>
+    </div>
+    <div class="card-body">
+        <form method="get" action="{{ url_for('repair.create_forklift_repair_select') }}" class="row g-3">
+            <div class="col-md-4">
+                <label for="keyword" class="form-label">キーワード</label>
+                <input type="text" class="form-control" id="keyword" name="keyword" value="{{ search_keyword }}" placeholder="管理番号、メーカー、機種など">
+            </div>
+            <div class="col-md-4">
+                <label for="warehouse_group" class="form-label">倉庫グループ</label>
+                <select class="form-select" id="warehouse_group" name="warehouse_group">
+                    <option value="">すべて</option>
+                    {% for group in warehouse_groups %}
+                    <option value="{{ group.name }}" {% if search_warehouse_group == group.name %}selected{% endif %}>{{ group.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-search"></i> 検索
+                </button>
+                <a href="{{ url_for('repair.create_forklift_repair_select') }}" class="btn btn-secondary ms-2">
+                    <i class="bi bi-x-circle"></i> クリア
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        <h5 class="card-title mb-0">フォークリフト一覧</h5>
+    </div>
+    <div class="card-body">
+        {% if forklifts %}
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>管理番号</th>
+                        <th>メーカー</th>
+                        <th>機種</th>
+                        <th>タイプ</th>
+                        <th>配置倉庫</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for forklift in forklifts %}
+                    <tr>
+                        <td>{{ forklift.management_number }}</td>
+                        <td>{{ forklift.manufacturer }}</td>
+                        <td>{{ forklift.model }}</td>
+                        <td>{{ forklift.type_name }}</td>
+                        <td>{{ forklift.warehouse_group }} {{ forklift.warehouse_number }}</td>
+                        <td>
+                            <a href="{{ url_for('repair.create_forklift_repair', forklift_id=forklift.id) }}" class="btn btn-sm btn-primary">
+                                <i class="bi bi-tools"></i> 修繕登録
+                            </a>
+                            <a href="{{ url_for('forklift.view', id=forklift.id) }}" class="btn btn-sm btn-info">
+                                <i class="bi bi-eye"></i> 詳細
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="text-center my-3">条件に一致するフォークリフトはありません。</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/repair/create_select.html
+++ b/app/templates/repair/create_select.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}修繕履歴登録 - 倉庫修繕費管理システム{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>修繕履歴登録</h1>
+    <a href="{{ url_for('repair.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> 一覧に戻る
+    </a>
+</div>
+
+<div class="row">
+    <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-body text-center">
+                <i class="bi bi-truck display-1 text-primary mb-3"></i>
+                <h3>フォークリフト修繕</h3>
+                <p>フォークリフトの修繕履歴を登録します。</p>
+                <a href="{{ url_for('repair.create_forklift_repair_select') }}" class="btn btn-primary">
+                    <i class="bi bi-plus-circle"></i> フォークリフト修繕登録
+                </a>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-body text-center">
+                <i class="bi bi-building display-1 text-success mb-3"></i>
+                <h3>倉庫施設修繕</h3>
+                <p>倉庫施設の修繕履歴を登録します。</p>
+                <a href="{{ url_for('repair.create_facility_repair_select') }}" class="btn btn-success">
+                    <i class="bi bi-plus-circle"></i> 倉庫施設修繕登録
+                </a>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-body text-center">
+                <i class="bi bi-tools display-1 text-warning mb-3"></i>
+                <h3>その他修繕</h3>
+                <p>その他の修繕履歴を登録します。</p>
+                <a href="{{ url_for('repair.create_other_repair') }}" class="btn btn-warning">
+                    <i class="bi bi-plus-circle"></i> その他修繕登録
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/repair/index.html
+++ b/app/templates/repair/index.html
@@ -5,9 +5,60 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>修繕履歴一覧</h1>
-    <a href="{{ url_for('repair.create_other_repair') }}" class="btn btn-primary">
-        <i class="bi bi-plus-circle"></i> その他修繕登録
-    </a>
+    <div>
+        <a href="{{ url_for('repair.create_select') }}" class="btn btn-primary">
+            <i class="bi bi-plus-circle"></i> 新規修繕登録
+        </a>
+    </div>
+</div>
+
+<!-- 検索フォーム -->
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">検索条件</h5>
+    </div>
+    <div class="card-body">
+        <form method="get" action="{{ url_for('repair.index') }}" class="row g-3">
+            <div class="col-md-3">
+                <label for="type" class="form-label">修繕対象</label>
+                <select class="form-select" id="type" name="type">
+                    <option value="all" {% if search_type == 'all' %}selected{% endif %}>すべて</option>
+                    <option value="forklift" {% if search_type == 'forklift' %}selected{% endif %}>フォークリフト</option>
+                    <option value="facility" {% if search_type == 'facility' %}selected{% endif %}>倉庫施設</option>
+                    <option value="other" {% if search_type == 'other' %}selected{% endif %}>その他</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label for="keyword" class="form-label">キーワード</label>
+                <input type="text" class="form-control" id="keyword" name="keyword" value="{{ search_keyword }}" placeholder="修繕項目、管理番号など">
+            </div>
+            <div class="col-md-2">
+                <label for="date_from" class="form-label">修繕日（開始）</label>
+                <input type="date" class="form-control" id="date_from" name="date_from" value="{{ search_date_from }}">
+            </div>
+            <div class="col-md-2">
+                <label for="date_to" class="form-label">修繕日（終了）</label>
+                <input type="date" class="form-control" id="date_to" name="date_to" value="{{ search_date_to }}">
+            </div>
+            <div class="col-md-2">
+                <label for="reason" class="form-label">修繕理由</label>
+                <select class="form-select" id="reason" name="reason">
+                    <option value="">すべて</option>
+                    {% for reason_key, reason_name in repair_reasons.items() %}
+                    <option value="{{ reason_key }}" {% if search_reason == reason_key %}selected{% endif %}>{{ reason_name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-12 text-end">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-search"></i> 検索
+                </button>
+                <a href="{{ url_for('repair.index') }}" class="btn btn-secondary">
+                    <i class="bi bi-x-circle"></i> クリア
+                </a>
+            </div>
+        </form>
+    </div>
 </div>
 
 <div class="card mb-4">


### PR DESCRIPTION
## 概要
修繕履歴管理機能を改善しました。

## 変更内容
1. 修繕履歴一覧ページに検索機能を追加
   - 修繕対象、キーワード、日付範囲、修繕理由による検索が可能
2. 新規登録ページを別ページに分離
   - 修繕対象（フォークリフト、倉庫施設、その他）選択ページを追加
3. 登録時に対象施設・フォークリフトをマスタから選択できるように改善
   - フォークリフト選択ページを追加（検索機能付き）
   - 倉庫施設選択ページを追加（検索機能付き）
4. フォークリフト・倉庫施設一覧画面からも登録できるように改善
   - 詳細ページの修繕履歴追加ボタンを新しいルートに更新

## 関連Issue
Closes #23

## テスト方法
1. 修繕履歴一覧ページで検索機能を使用
2. 新規修繕登録から各種修繕履歴を登録
3. フォークリフト詳細ページから修繕履歴を登録
4. 倉庫施設詳細ページから修繕履歴を登録